### PR TITLE
add compiler flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ EXEC=ihcserver
 SRCS=$(shell ls *.cpp)
 OBJS=$(SRCS:%.cpp=%.o)
 CPPFLAGS+=-g -Wall -W
+CXXFLAGS=-std=c++14
 
 all: $(LIBS) $(OBJS)
 	g++ -o $(EXEC) $(OBJS) $(LIBS) $(LDLIBS)


### PR DESCRIPTION
If newer compilers gives you errors like this

```
Configuration.h:45:21: error: ISO C++17 does not allow dynamic exception specifications
   45 |         void load() throw (bool);
      |                     ^~~~~
```

you need to add the CXXFLAGS option to Makefile.